### PR TITLE
Use [ text, clob ] instead of [ clob, text ].

### DIFF
--- a/MDB2/Driver/Datatype/pgsql.php
+++ b/MDB2/Driver/Datatype/pgsql.php
@@ -451,7 +451,6 @@ class MDB2_Driver_Datatype_pgsql extends MDB2_Driver_Datatype_Common
                 }
             } elseif (strstr($db_type, 'text')) {
                 $type[] = 'clob';
-                $type = array_reverse($type);
             }
             if ($fixed !== false) {
                 $fixed = true;


### PR DESCRIPTION
See discussion on https://pear.php.net/bugs/bug.php?id=12269.
