### PR TITLE
Update to support new object types in PHP 8.1

### DIFF
--- a/MDB2/Driver/Datatype/pgsql.php
+++ b/MDB2/Driver/Datatype/pgsql.php
@@ -286,15 +286,12 @@ class MDB2_Driver_Datatype_pgsql extends MDB2_Driver_Datatype_Common
                 return $value;
             }
         }
-        if (version_compare(PHP_VERSION, '5.2.0RC6', '>=')) {
-            $connection = $db->getConnection();
-            if (MDB2::isError($connection)) {
-                return $connection;
-            }
-            $value = @pg_escape_bytea($connection, $value);
-        } else {
-            $value = @pg_escape_bytea($value);
+        $connection = $db->getConnection();
+        if (MDB2::isError($connection)) {
+            return $connection;
         }
+        $value = @pg_escape_bytea($connection, $value);
+
         return "'".$value."'";
     }
 

--- a/MDB2/Driver/Reverse/pgsql.php
+++ b/MDB2/Driver/Reverse/pgsql.php
@@ -536,7 +536,7 @@ class MDB2_Driver_Reverse_pgsql extends MDB2_Driver_Reverse_Common
         }
 
         $resource = MDB2::isResultCommon($result) ? $result->getResource() : $result;
-        if (!is_resource($resource)) {
+        if (!is_a($resource, 'PgSql\Result') && !is_resource($resource)) {
             return $db->raiseError(
                 MDB2_ERROR_NEED_MORE_DATA,
                 null,

--- a/MDB2/Driver/pgsql.php
+++ b/MDB2/Driver/pgsql.php
@@ -216,12 +216,8 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
             return $connection;
         }
 
-        if ((is_a($connection, 'PgSql\Connection') || is_resource($connection))
-            && version_compare(PHP_VERSION, '5.2.0RC5', '>=')
-        ) {
+        if ((is_a($connection, 'PgSql\Connection') || is_resource($connection))) {
             $text = @pg_escape_string($connection, $text);
-        } else {
-            $text = @pg_escape_string($text);
         }
         return $text;
     }
@@ -452,9 +448,7 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
         }
 
         if ($this->isNewLinkSet()) {
-            if (version_compare(phpversion(), '4.3.0', '>=')) {
-                $params[] = PGSQL_CONNECT_FORCE_NEW;
-            }
+            $params[] = PGSQL_CONNECT_FORCE_NEW;
         }
 
         $connect_function = $persistent ? 'pg_pconnect' : 'pg_connect';

--- a/MDB2/Driver/pgsql.php
+++ b/MDB2/Driver/pgsql.php
@@ -118,7 +118,7 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
         $error_code = MDB2_ERROR;
 
         $native_msg = '';
-        if (is_a($resource, 'PgSql\Result') || is_resource($resource)) {
+        if (is_a($error, 'PgSql\Result') || is_resource($error)) {
             $native_msg = @pg_result_error($error);
         } elseif ($this->connection) {
             $native_msg = @pg_last_error($this->connection);

--- a/MDB2/Driver/pgsql.php
+++ b/MDB2/Driver/pgsql.php
@@ -118,7 +118,7 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
         $error_code = MDB2_ERROR;
 
         $native_msg = '';
-        if (is_resource($error)) {
+        if (is_a($resource, 'PgSql\Result') || is_resource($resource)) {
             $native_msg = @pg_result_error($error);
         } elseif ($this->connection) {
             $native_msg = @pg_last_error($this->connection);
@@ -215,7 +215,10 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
         if (MDB2::isError($connection)) {
             return $connection;
         }
-        if (is_resource($connection) && version_compare(PHP_VERSION, '5.2.0RC5', '>=')) {
+
+        if ((is_a($connection, 'PgSql\Connection') || is_resource($connection))
+            && version_compare(PHP_VERSION, '5.2.0RC5', '>=')
+        ) {
             $text = @pg_escape_string($connection, $text);
         } else {
             $text = @pg_escape_string($text);
@@ -536,7 +539,9 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
      */
     public function connect()
     {
-        if (is_resource($this->connection)) {
+        if (is_a($this->connection, 'PgSql\Connection')
+            || is_resource($this->connection)
+        ) {
             //if (count(array_diff($this->connected_dsn, $this->dsn)) == 0
             if (MDB2::areEquals($this->connected_dsn, $this->dsn)
                 && $this->connected_database_name == $this->database_name
@@ -644,7 +649,9 @@ class MDB2_Driver_pgsql extends MDB2_Driver_Common
      */
     public function disconnect($force = true)
     {
-        if (is_resource($this->connection)) {
+        if (is_a($this->connection, 'PgSql\Connection')
+            || is_resource($this->connection)
+        ) {
             if ($this->in_transaction) {
                 $dsn = $this->dsn;
                 $database_name = $this->database_name;

--- a/MDB2/Result/pgsql.php
+++ b/MDB2/Result/pgsql.php
@@ -232,7 +232,9 @@ class MDB2_Result_pgsql extends MDB2_Result_Common
      */
     public function free()
     {
-        if (is_resource($this->result) && $this->db->connection) {
+        if ((is_a($this->result, 'PgSql\Result') || is_resource($this->result))
+            && $this->db->connection
+        ) {
             $free = @pg_free_result($this->result);
             if (false === $free) {
                 return $this->db->raiseError(


### PR DESCRIPTION
Using `is_a` instead of `instanceof` so that we don't try to autoload a non-existent class in PHP 7.x.