### PR TITLE
Add support for citext datatype [sc-75077]

### DIFF
--- a/MDB2/Driver/Datatype/pgsql.php
+++ b/MDB2/Driver/Datatype/pgsql.php
@@ -497,6 +497,7 @@ class MDB2_Driver_Datatype_pgsql extends MDB2_Driver_Datatype_Common
 
             case 'text':
             case 'varchar':
+            case 'citext':
                 $fixed = false;
 
                 // no break


### PR DESCRIPTION
# Description

Adds support for the `citext` datatype, treating it like a `text` datatype.

# Testing

1. Before applying this change, open up https://berna.silverorange.com/emrap/work-USERNAME/www/admin/ and you'll see the following error:

> **Caught Exception: SwatDBException**
>
> Message:
>    MDB2 Error: not supported
>    mapNativeDatatypeInternal: [Error message: unknown database attribute type: citext]
>    [Last executed query: select Account.*
>    from Account
>    where Account.referral_tax_enabled is null
>    and id in (
>    select ReferralReward.account
>    from ReferralReward
>    where ReferralReward.reward_type != 3
>    and extract(YEAR from ReferralReward.rewarded_date) = extract(YEAR from CURRENT_DATE)
>    group by ReferralReward.account
>    having sum(ReferralReward.reward_value) > 550
>    )]

2. Apply the change (either via symlinking on berna, or just manually editing the one file `vendor/silverorange/mdb2_driver_pgsql/MDB2/Driver/Datatype/pgsql.php` and reload the page; the error is fixed.
