### PR TITLE
Public cleanup

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -11,7 +11,7 @@ return (new Config())
     ->setParallelConfig(ParallelConfigFactory::detect(null, null, 2 ** 18 - 1))
     ->setRules([
         '@PhpCsFixer'      => true,
-        '@PHP82Migration'  => true,
+        '@PHP8x2Migration' => true,
         'indentation_type' => true,
 
         // Overrides for (opinionated) @PhpCsFixer and @Symfony rules:
@@ -21,6 +21,9 @@ return (new Config())
 
         // Subset of statements that should be proceeded with blank line
         'blank_line_before_statement' => ['statements' => ['case', 'continue', 'declare', 'default', 'return', 'throw', 'try', 'yield', 'yield_from']],
+
+        // Allow class list for multiple extends/implements to span multiple lines
+        'class_definition' => ['multi_line_extends_each_single_line' => true],
 
         // Enforce space around concatenation operator
         'concat_space' => ['spacing' => 'one'],

--- a/MDB2/Result/pgsql.php
+++ b/MDB2/Result/pgsql.php
@@ -56,7 +56,7 @@ class MDB2_Result_pgsql extends MDB2_Result_Common
      * @param int $fetchmode how the array data should be indexed
      * @param int $rownum    number of the row where the data can be found
      *
-     * @return int data array on success, a MDB2 error on failure
+     * @return ($fetchmode is MDB2_FETCHMODE_OBJECT ? stdClass : array)|MDB2_Error data array on success, a MDB2 error on failure
      */
     public function fetchRow($fetchmode = MDB2_FETCHMODE_DEFAULT, $rownum = null)
     {

--- a/composer.json
+++ b/composer.json
@@ -17,26 +17,26 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=8.2",
     "ext-mbstring": "*",
     "ext-pgsql": "*",
     "pear/pear-core-minimal": "^1.9.0",
     "silverorange/mdb2": "^3.1.2"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.64.0",
-    "phpstan/phpstan": "^1.12",
-    "rector/rector": "^1.2"
+    "friendsofphp/php-cs-fixer": "3.88.2",
+    "phpstan/phpstan": "^2.2",
+    "rector/rector": "^2.4"
   },
   "scripts": {
     "phpcs": "./vendor/bin/php-cs-fixer check -v",
     "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
-    "phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
+    "phpcs:fix": "./vendor/bin/php-cs-fixer fix -v",
     "phpstan": "./vendor/bin/phpstan analyze",
     "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
     "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
     "rector": "./vendor/bin/rector --dry-run",
-    "rector:write": "./vendor/bin/rector"
+    "rector:fix": "./vendor/bin/rector"
   },
   "autoload": {
     "classmap": [

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+
+return RectorConfig::configure()
+    // Set the correct paths to all the PHP files in your project
+    ->withPaths([
+        __DIR__ . '/MDB2',
+    ])
+    ->withFileExtensions([
+        'php',
+        'inc',
+    ])
+    // Choose the correct PHP version for your project
+    ->withPhpSets(php82: true)
+    ->withRules([
+        // any additional rules can be added here
+        // see https://getrector.com/find-rule
+    ])
+    ->withSkip([
+        // any rules that are part of the PHP set but that you want
+        // to skip can be listed here.  The following are common ones
+        // that introduce a lot of changes to legacy code bases.
+        // For new projects, you should probably not skip anything.
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        NullToStrictStringFuncCallArgRector::class,
+        RemoveUnusedVariableInCatchRector::class,
+    ])
+    // See https://getrector.com/documentation/integration-to-new-project
+    // for other configuration settings
+    ->withTypeCoverageLevel(1)
+    ->withDeadCodeLevel(0);


### PR DESCRIPTION
- bumps a few versions and standardizes formatting rules, commands, etc..

One unrelated change: tweak the PHPstan annotation for the `fetchRow()` function to match the parent class (see https://github.com/silverorange/MDB2/pull/25)